### PR TITLE
Ubuntu and OSX Github Actions, updated developing instructions

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -1,0 +1,36 @@
+name: Build on OSX
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-osx:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install building dependencies
+        run: brew install python-setuptools libx11 libxkbfile
+
+      - name: Install python deps
+        run: sudo apt update && sudo apt install python3-setuptools
+    
+      - name: Install building dependencies
+        run: sudo apt install libx11-dev libxkbfile-dev
+
+      - name: Install Yarn
+        run: yarn install
+
+      - name: Download default plugins
+        run: yarn download:plugins
+
+      - name: Build Browser version
+        run: yarn build:browser

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,37 @@
+name: Build on Ubuntu
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-osx:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install building dependencies
+        run: brew install python-setuptools libx11 libxkbfile
+
+      - name: Install python deps
+        run: sudo apt update && sudo apt install python3-setuptools
+    
+      - name: Install building dependencies
+        run: sudo apt update &&
+             sudo apt install python3-setuptools libx11-dev libxkbfile-dev
+
+      - name: Install Yarn
+        run: yarn install
+
+      - name: Download default plugins
+        run: yarn download:plugins
+
+      - name: Build Browser version
+        run: yarn build:browser

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -4,17 +4,35 @@ Recommended to use [nvm](https://github.com/creationix/nvm#install-script).
 
 Install npm and node.
 
-    nvm install v20
-    nvm use v20
+```bash
+nvm install v20
+nvm use v20
+```
 
 Install yarn.
 
-    npm install -g yarn
+```bash
+npm install -g yarn
+```
 
 ## Gather dependencies / Initialize
 
-    cd CodeRibbon-Theia
-    yarn
+In order to develop or build, ensure that you have [node-gyp](https://github.com/nodejs/node-gyp)'s dependencies installed.
+
+Ubuntu:
+```bash
+sudo apt-get install -y python-setuptools libx11-dev libxkbfile-dev
+```
+
+OSX:
+```bash
+brew install python-setuptools libx11 libxkbfile
+```
+
+```bash
+cd CodeRibbon-Theia
+yarn
+```
 
 You may need additional libraries to build depending on what you are building.
 
@@ -22,9 +40,11 @@ You may need additional libraries to build depending on what you are building.
 
 Start watching either type of build you're working with:
 
-    yarn watch:browser
-    # or
-    yarn watch:electron
+```bash
+yarn watch:browser
+# or
+yarn watch:electron
+```
 
 > right now there seems to be a problem with the 'watch' automatic recompilation, for now just use `build:*` instead.
 
@@ -36,6 +56,8 @@ You can change the port the browser app runs on like `yarn start:browser --port 
 
 ## Including default plugins
 
-    yarn download:plugins
+```bash
+yarn download:plugins
+```
 
 Pulls down the Theia & VSCode plugins that are "built-in" in to the application when it's packaged.


### PR DESCRIPTION
To address build errors I got on my MacBook, listed here:

https://github.com/nodejs/node-gyp/issues/2869 + https://stackoverflow.com/questions/55878536/no-package-xkbfile-found-when-build-vscode-on-ubuntu + https://github.com/nodejs/node-gyp/issues/2869 + https://stackoverflow.com/questions/55878536/no-package-xkbfile-found-when-build-vscode-on-ubuntu

I updated the develop instructions to include dependencies that are not installed through yarn, and added workflows to detect these issues in the future (triggered by manual dispatch)